### PR TITLE
Fixed Overflow of text

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -125,6 +125,7 @@ button:hover {
   align-items: center;
   text-align: left;
   transition: all 0.5s ease;
+  overflow-wrap: anywhere;
 }
 .task p {
   font-size: 1rem;


### PR DESCRIPTION
if user writes anything in the input box without giving any spaces (example : sdjbkjdbskjdbsdbskdbsksdfdsf) then the text overflows. I have added overflow-wrap property to fix that